### PR TITLE
Add zoom transition with improved timing

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,36 +275,47 @@
                     "maxItems": 4,
                     "items": {
                         "type": "number",
-                        "minimum": 0
+                    "minimum": 0
                     }
+                },
+                "background.backgroundTransitionEffect": {
+                    "markdownDescription": "Transition animation when switching images.",
+                    "type": "string",
+                    "order": 12,
+                    "default": "Fade",
+                    "enum": ["Fade", "Zoom"],
+                    "enumDescriptions": [
+                        "Cross fade between images",
+                        "Zoom out and fade"
+                    ]
                 },
                 "background.autoInstall": {
                     "markdownDescription": "Automatically installs backgrounds and reloads the window on startup if changes are detected or VSCode updates.\n\nThis option is disabled when you run the uninstall command.",
-                    "order": 12,
+                    "order": 13,
                     "type": "boolean",
                     "default": false
                 },
                 "background.renderContentAboveBackground": {
                     "markdownDescription": "Render content like images, PDFs, and markdown previews above the background.",
-                    "order": 13,
+                    "order": 14,
                     "type": "boolean",
                     "default": false
                 },
                 "background.useInvertedOpacity": {
                     "markdownDescription": "Use an inverted opacity, so 0 is fully visible and 1 is invisible.",
-                    "order": 14,
+                    "order": 15,
                     "type": "boolean",
                     "default": false
                 },
                 "background.smoothImageRendering": {
                     "markdownDescription": "Use smooth image rendering rather than pixelated rendering when resizing images.",
-                    "order": 15,
+                    "order": 16,
                     "type": "boolean",
                     "default": false
                 },
                 "background.settingScope": {
                     "markdownDescription": "Where to save and load background settings.\n\nThis does not automatically update the background on workspace change, you need to also turn on `#background.autoInstall#`.",
-                    "order": 16,
+                    "order": 17,
                     "type": "string",
                     "enum": [
                         "Global",
@@ -314,7 +325,7 @@
                 },
                 "background.CSS": {
                     "markdownDescription": "Apply raw CSS to VSCode.",
-                    "order": 17,
+                    "order": 18,
                     "type": "string",
                     "editPresentation": "multilineText",
                     "default": ""

--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -54,8 +54,9 @@ const getJavaScript: () => string = () => {
     };
 
     const after: boolean = get("renderContentAboveBackground");
+    const effect: string = get("backgroundTransitionEffect");
 
-    return `(() => {` +
+    return `(() => {const run = () => {` +
 // shared background css
 `
 const bk_global = document.createElement("style");
@@ -71,6 +72,7 @@ bk_global.appendChild(document.createTextNode(\`
     body[panelTransition="true"] .split-view-view > .part.panel::after {
 
         opacity: 0;
+        ${effect === 'Zoom' ? 'transform: scale(1.2);' : ''}
 
     }
 
@@ -93,9 +95,10 @@ bk_global.appendChild(document.createTextNode(\`
 
         pointer-events: none;
 
-        transition: opacity 1s ease-in-out;
+        transition: opacity 1s ease-in-out${effect === 'Zoom' ? ', transform 1s ease-in-out' : ''};
 
         image-rendering: ${get("smoothImageRendering") ? "auto" : "pixelated"};
+        ${effect === 'Zoom' ? 'transform: scale(1);' : ''}
 
     }
 \`));
@@ -390,7 +393,13 @@ if(panelTime > 0 && iPanelBackgrounds.length > 1){
     }, panelTime * 1000);
 };
 ` +
-            `})();`;
+            `};
+if(document.readyState === "loading"){
+    window.addEventListener("DOMContentLoaded", run);
+}else{
+    run();
+}
+})();`;
 }
 
 const minifyJavaScript: (javascript: string) => string = (javascript: string) =>

--- a/src/extension/package.ts
+++ b/src/extension/package.ts
@@ -31,6 +31,7 @@ export type ConfigurationKey =
     "backgroundSize" |
     "backgroundSizeValue" |
     "backgroundChangeTime" |
+    "backgroundTransitionEffect" |
     "autoInstall" |
     "renderContentAboveBackground" |
     "useInvertedOpacity" |

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -33,6 +33,7 @@ import { show as opacityMenu } from "./opacity";
 import { show as repeatMenu } from "./repeat";
 import { show as sizeMenu } from "./size";
 import { show as timeMenu } from "./time";
+import { show as transitionMenu } from "./transition";
 
 const issueUrl: string = `https://github.com/KatsuteDev/Background/issues/new?template=bug.yml&os=${encodeURIComponent(`${platform()} ${release()}`)}&vs=${encodeURIComponent(version)}&version=${encodeURIComponent(pkg.version)}`;
 const featureUrl: string = "https://github.com/KatsuteDev/Background/issues/new?template=feature.yml";
@@ -219,6 +220,13 @@ export const backgroundMenu: (ui: UI) => void = (ui: UI) =>
             detail: "Background image size",
             ui,
             handle: () => sizeMenu(ui)
+        }),
+        quickPickItem({
+            label: "$(debug-start) Transition",
+            description: `${get("backgroundTransitionEffect")}`,
+            detail: "Image transition effect",
+            ui,
+            handle: () => transitionMenu(ui)
         }),
         quickPickItem({
             label: "$(clock) Time",

--- a/src/menu/transition.ts
+++ b/src/menu/transition.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Katsute <https://github.com/Katsute>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import { UI, get, updateFromLabel } from "../extension/config";
+import { getConfigurationProperty } from "../extension/package";
+
+import { CommandQuickPickItem, quickPickItem, showQuickPick } from "../lib/vscode";
+
+import { backgroundMenu, title } from "./menu";
+
+const prop: any = getConfigurationProperty("backgroundTransitionEffect");
+
+const handle: (item: CommandQuickPickItem) => void = (item: CommandQuickPickItem) =>
+    updateFromLabel("backgroundTransitionEffect", item)
+        .then(() => backgroundMenu(item.ui!));
+
+export const show: (ui: UI) => void = (ui: UI) => {
+    const current: string = get("backgroundTransitionEffect") as string;
+
+    showQuickPick([
+        quickPickItem({ label: prop.enum![0], description: prop.enumDescriptions![0], handle, ui }, current),
+        quickPickItem({ label: prop.enum![1], description: prop.enumDescriptions![1], handle, ui }, current)
+    ], {
+        title: title("Transition", ui),
+        matchOnDescription: true,
+        placeHolder: "Transition effect"
+    });
+};


### PR DESCRIPTION
## Summary
- add `backgroundTransitionEffect` config to control animation style
- integrate transition setting with configuration menus
- ensure timing code waits for the DOM to load and support a new zoom effect

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684aee8566c4833189f14662b9043372